### PR TITLE
Fixed #62

### DIFF
--- a/Sources/StepperView/Views/StepIndicatorVerticalView.swift
+++ b/Sources/StepperView/Views/StepIndicatorVerticalView.swift
@@ -60,7 +60,7 @@ struct StepIndicatorVerticalView<Cell>: View where Cell:View {
                      lineYPosition: $lineYPosition,
                      options: self.lineOptions,
                      alignments: (self.firstAlignment, self.lastAlignment))
-            VStack(spacing: autoSpacing ? self.dynamicSpace : self.verticalSpacing) {
+			VStack(alignment: .leading, spacing: autoSpacing ? self.dynamicSpace : self.verticalSpacing) {
                 ForEach(0..<self.cells.count, id:\.self) { index in
                     HStack(alignment: self.getAlignment(type: self.alignments[index])) {
                         IndicatorView(type: self.indicationType[index], indexofIndicator: index)

--- a/Sources/StepperView/Views/StepIndicatorVerticalView.swift
+++ b/Sources/StepperView/Views/StepIndicatorVerticalView.swift
@@ -60,7 +60,7 @@ struct StepIndicatorVerticalView<Cell>: View where Cell:View {
                      lineYPosition: $lineYPosition,
                      options: self.lineOptions,
                      alignments: (self.firstAlignment, self.lastAlignment))
-			VStack(alignment: .leading, spacing: autoSpacing ? self.dynamicSpace : self.verticalSpacing) {
+            VStack(alignment: .leading, spacing: autoSpacing ? self.dynamicSpace : self.verticalSpacing) {
                 ForEach(0..<self.cells.count, id:\.self) { index in
                     HStack(alignment: self.getAlignment(type: self.alignments[index])) {
                         IndicatorView(type: self.indicationType[index], indexofIndicator: index)


### PR DESCRIPTION
## Description
The main `VStack` in `StepIndicatorVerticalView` was missing `aligment: .leading` due to which all steps were centre aligned

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested
I have tested my PR and now all the steps are aligned perfectly with the vertical line.

## Test Configuration

<ul>
 <li> Xcode version: 12.3</li>
 <li> Simulator</li>
 <li> iOS version: iOS 14.3</li>
</ul>

## Checklist:

 For checklist items not applicable, mention NA in front of it with some comment if applicable.

 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] NA - Add comments to code particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes before pushing the pull request
