### PR TITLE
Center rounded line alignment for StepIndicatorVerticalView

### DIFF
--- a/Sources/StepperView/Views/StepIndicatorVerticalView.swift
+++ b/Sources/StepperView/Views/StepIndicatorVerticalView.swift
@@ -224,7 +224,7 @@ extension StepIndicatorVerticalView {
             return RoundedRectangle(cornerRadius: cornerRadius)
                 .foregroundColor(stepLifeCycle[index] == StepLifeCycle.completed ? color : Color.gray.opacity(0.5))
                 .frame(width: width, height: self.verticalSpacing)
-                .offset(x: proxy[value].midX - width, y: proxy[value].maxY)
+                .offset(x: proxy[value].midX - width/2, y: proxy[value].maxY)
                 .eraseToAnyView()
         default:
             return EmptyView().eraseToAnyView()


### PR DESCRIPTION
## Description

This small change corrects the center-alignment of rounded lines in StepIndicatorVerticalView. Other vertical line types and all horizontal line types have not been tested and may also need a similar fix if they are also subtracting the full width of the line rather than half.
| Before | After |
|--------|------|
| ![Screen Shot 2021-05-19 at 2 57 45 PM](https://user-images.githubusercontent.com/26018831/118892618-07d6ac00-b8b6-11eb-92ca-db83b8c2488e.png) | ![Screen Shot 2021-05-19 at 2 58 52 PM](https://user-images.githubusercontent.com/26018831/118892639-0efdba00-b8b6-11eb-9ac8-4d8ad8d8e7b2.png) |



## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested

This has been manually tested for the vertical rounded line type. The code in question is only used for that type of line, so it should not break any other types.

## Test Configuration

<ul>
 <li> Xcode version: 12.4</li>
 <li> Device/Simulator 11 Pro simulator </li>
 <li> iOS version 14.4</li>
 <li> MacOSX version 11.2.1</li>
</ul>

## Checklist:

 For checklist items not applicable, mention NA in front of it with some comment if applicable.

 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] Add comments to code particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
 - NA I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes before pushing the pull request
