### PR TITLE
Add support for custom colors for lines in .pending state

### DIFF
--- a/Sources/StepperView/Views/Lines/HorizontalLineView.swift
+++ b/Sources/StepperView/Views/Lines/HorizontalLineView.swift
@@ -32,7 +32,7 @@ struct HorizontalLineView: View {
             .frame(width: dividerWidth, height: height)
             .offset(y: -(lineYOffsetPosition + 1))
             .eraseToAnyView()
-        case .rounded(_,_,_):
+        case .rounded(_,_,_,_):
             return EmptyView().eraseToAnyView()
         }
     }

--- a/Sources/StepperView/Views/Lines/PitStopLineView.swift
+++ b/Sources/StepperView/Views/Lines/PitStopLineView.swift
@@ -35,7 +35,7 @@ struct PitStopLineView: View {
                 .frame(width: width, height: proxy.size.height)
                 .offset(x: proxy[value].midX - self.width / 2 - (width + 1), y: proxy[value].maxY)
                 .eraseToAnyView()
-        case .rounded(_, _, _):
+        case .rounded(_, _, _, _):
             return EmptyView().eraseToAnyView()
         }
     }

--- a/Sources/StepperView/Views/Lines/VerticalLineView.swift
+++ b/Sources/StepperView/Views/Lines/VerticalLineView.swift
@@ -41,7 +41,7 @@ struct VerticalLineView: View {
                             y: getYOffsetPosition(for: alignments.0, last: alignments.1, and: lineYPosition))
                     .padding()
                     .eraseToAnyView()
-        case .rounded(_, _, _):
+        case .rounded(_, _, _, _):
             return EmptyView().eraseToAnyView()
         }
     }

--- a/Sources/StepperView/Views/StepIndicatorHorizontalView.swift
+++ b/Sources/StepperView/Views/StepIndicatorHorizontalView.swift
@@ -51,7 +51,7 @@ struct StepIndicatorHorizontalView<Cell:View>: View {
            self.horizontalSpacing = horizontalSpacing
            self.lineOptions = lineOptions
              switch lineOptions {
-             case .rounded(_, _, _):
+             case .rounded(_, _, _, _):
                       self.isRounded = true
              default: self.isRounded = false
           }
@@ -136,10 +136,10 @@ struct StepIndicatorHorizontalView<Cell:View>: View {
     private func drawCustomLine(proxy: GeometryProxy, value: Anchor<CGRect>, index: Int) -> some View {
         guard index != self.cells.count - 1 else { return EmptyView().eraseToAnyView() }
         switch lineOptions {
-        case .rounded(let width, let cornerRadius, let color):
+        case .rounded(let width, let cornerRadius, let color, let pendingColor):
             // draw a line
             return RoundedRectangle(cornerRadius: cornerRadius)
-                .foregroundColor(stepLifeCycle[index] == StepLifeCycle.completed ? color : Color.gray.opacity(0.5))
+                .foregroundColor(stepLifeCycle[index] == StepLifeCycle.completed ? color : pendingColor)
                 .frame(width: self.horizontalSpacing, height: width)
                 .offset(x: proxy[value].maxX + width, y: proxy[value].midY)
                 .eraseToAnyView()

--- a/Sources/StepperView/Views/StepIndicatorVerticalView.swift
+++ b/Sources/StepperView/Views/StepIndicatorVerticalView.swift
@@ -58,7 +58,7 @@ struct StepIndicatorVerticalView<Cell>: View where Cell:View {
            self.verticalSpacing = verticalSpacing
            self.lineOptions = lineOptions
             switch lineOptions {
-            case .rounded(_, _, _):
+            case .rounded(_, _, _, _):
                      self.isRounded = true
             default: self.isRounded = false
             }
@@ -219,10 +219,10 @@ extension StepIndicatorVerticalView {
     private func drawCustomLine(proxy: GeometryProxy, value: Anchor<CGRect>, index: Int) -> some View {
         guard index != self.cells.count - 1 else { return EmptyView().eraseToAnyView() }
         switch lineOptions {
-        case .rounded(let width, let cornerRadius, let color):
+        case .rounded(let width, let cornerRadius, let color, let pendingColor):
             // draw a line
             return RoundedRectangle(cornerRadius: cornerRadius)
-                .foregroundColor(stepLifeCycle[index] == StepLifeCycle.completed ? color : Color.gray.opacity(0.5))
+                .foregroundColor(stepLifeCycle[index] == StepLifeCycle.completed ? color : pendingColor)
                 .frame(width: width, height: self.verticalSpacing)
                 .offset(x: proxy[value].midX - width/2, y: proxy[value].maxY)
                 .eraseToAnyView()

--- a/Sources/StepperView/Views/StepperView.swift
+++ b/Sources/StepperView/Views/StepperView.swift
@@ -105,8 +105,8 @@ public enum StepperLineOptions {
     case defaults
     /// custom line option with `width`  and  `Color`
     case custom(CGFloat, Color)
-    /// rounded line options with `width` , `corner radius`  and   `Color`
-    case rounded(CGFloat, CGFloat, Color)
+    /// rounded line options with `width` , `corner radius`, `completed color`  and   `pending color`
+    case rounded(CGFloat, CGFloat, Color, Color = Color.gray.opacity(0.5))
 }
 
 /**


### PR DESCRIPTION
## Description

Add support for custom colors for lines in `.pending` state

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested

Manually tested to change colors of rounded lines in pending state

<ul>
 <li> Unit Testing </li>
 <li> UI Testing </li>
</ul>

## Test Configuration

<ul>
 <li> Xcode version: 12.4</li>
 <li> Device/Simulator 11 Pro simulator</li>
 <li> iOS version 14.4</li>
 <li> MacOSX version 11.2.1</li>
</ul>

## Checklist:

 For checklist items not applicable, mention NA in front of it with some comment if applicable.

 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] Add comments to code particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
 - NA I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes before pushing the pull request
