### PR TITLE
Add macOS support implement #46

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "StepperView",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v11), .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
## Description

Added macOS support by adding macOS specifier to package.swift file. No other change is made to the codebase.

**Note: Adding macOS support will break some examples usage that uses class such as `UIColor` and `UIScreen`, @badrinathvm you might want to update those examples.**

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested

No additional unit test added.

## Test Configuration

<ul>
 <li> Xcode version: 12.5 </li>
 <li> Device/Simulator: Simulator iPhone iOS 15 </li>
 <li> iOS version: 15.0 </li>
 <li> MacOSX version: 11.5 Beta </li>
</ul>

## Checklist:

 For checklist items not applicable, mention NA in front of it with some comment if applicable.

 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] Add comments to code particularly in hard-to-understand areas
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes before pushing the pull request
