### PR TITLE
[PR Request] - Removes default .black rendering for CircledIconView

### DIFF
--- a/Sources/StepperView/Extension/View+Extensions.swift
+++ b/Sources/StepperView/Extension/View+Extensions.swift
@@ -206,3 +206,16 @@ public extension View {
         return EmptyView()
     }
 }
+
+// MARK: - Helper function of View to operate on.
+/// Helper function of  `View`  to operate on
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension View {
+    func `if`<Content: View>(_ conditional: Bool, content: (Self) -> Content) -> TupleView<(Self?, Content?)> {
+        if conditional {
+            return TupleView((nil, content(self)))
+        } else {
+            return TupleView((self, nil))
+        }
+    }
+}

--- a/Sources/StepperView/Views/Indicators/CircledIconView.swift
+++ b/Sources/StepperView/Views/Indicators/CircledIconView.swift
@@ -40,7 +40,7 @@ public struct CircledIconView: View {
                     .overlay(image
                         .resizable()
                         .if(color != nil){
-                              $0.renderingMode(.template).renderingMode(.template)
+                              $0.renderingMode(.template).foregroundColor(color)
                         }
                         .frame(width: width/2, height: width/2)
                         .aspectRatio(contentMode: .fit)))

--- a/Sources/StepperView/Views/Indicators/CircledIconView.swift
+++ b/Sources/StepperView/Views/Indicators/CircledIconView.swift
@@ -15,14 +15,14 @@ public struct CircledIconView: View {
     /// width for step indicator
     public var width:CGFloat
     /// color for step indicator
-    public var color:Color
+    public var color:Color?
     /// stroke color for step indicator
     public var strokeColor:Color
     /// detect the color scheme i.e., light or dark mode
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     
     /// initiazes `image` , `width` , `color` and  `strokeColor`
-    public init(image:Image, width:CGFloat, color: Color = Color.black, strokeColor: Color = Colors.blue(.lightSky).rawValue) {
+    public init(image:Image, width:CGFloat, color: Color?, strokeColor: Color = Colors.blue(.lightSky).rawValue) {
         self.image = image
         self.width = width
         self.color = color
@@ -39,8 +39,9 @@ public struct CircledIconView: View {
                     .stroke(strokeColor, lineWidth: 1)
                     .overlay(image
                         .resizable()
-                        .renderingMode(.template)
-                        .foregroundColor(self.color)
+                        .if(color != nil){
+                              $0.renderingMode(.template).renderingMode(.template)
+                        }
                         .frame(width: width/2, height: width/2)
                         .aspectRatio(contentMode: .fit)))
         }


### PR DESCRIPTION
The default was setting rending to template and color to .black.

## Description

Please include a summary of the change and which issue is fixed.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

## How Has This Been Tested

Please let us know if you have tested your PR and if we need to reproduce the issues. Also, please let us know if we need any relevant information for running the tests.

NOT TESTED

## Test Configuration

N/A

## Checklist:

 For checklist items not applicable, mention NA in front of it with some comment if applicable.

 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my own code
 - [X] Add comments to code particularly in hard-to-understand areas
 - [X] My changes generate no new warnings
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes before pushing the pull request
